### PR TITLE
update VD policy per feedback from September 2023 TC39 plenary

### DIFF
--- a/docs/draft-SECURITY.md
+++ b/docs/draft-SECURITY.md
@@ -2,22 +2,22 @@
 
 ## Reporting Guidelines
 
-- If the vulnerability is present in an implementation, then [report it directly](#reporting-a-vulnerability-to-projects) to the relevant project using their vulnerability reporting process.
-- If the vulnerability is present in a TC39 specification, [let us know](#reporting-a-vulnerability-to-tc39).
+- If a security issue is present in an implementation, then [report it directly](#reporting-to-projects) to the relevant project.
+- If a security issue is present in a TC39 specification, [let us know](#reporting-to-tc39).
   - Include any relevant links to corroborative information, e.g. vulnerability reports, reference IDs, etc.
-- If you are unable to determine whether the vulnerability is implementation-specific, [let us know](#reporting-a-vulnerability-to-tc39).
+- If you are unable to determine whether a security issue is implementation-specific, [let us know](#reporting-to-tc39).
 
-## Reporting a Vulnerability to TC39
+## Reporting to TC39
 
 - GitHub private vulnerability reporting (add link when available)
 - Send an email to `security@tc39.es`
 
-## Reporting a Vulnerability to Projects
+## Reporting to Projects
 
 > [!NOTE]
 > This list is not exhaustive.
 
-| Engine/Platform | Used In                | Report a Vulnerability                          |
+| Engine/Platform | Used In                | Link to Report                                  |
 | --------------- | ---------------------- | ----------------------------------------------- |
 | JavaScriptCore  | Safari                 | [Report](https://webkit.org/security-policy/)   |
 | Node            |                        | [Report](https://nodejs.dev/en/about/security/) |


### PR DESCRIPTION
ultimately, while I find nothing wrong with the terms we currently use in the document, I understand if some folks prefer to use a more general term both for semantics and to be inclusive of a broader scope of issues where 'vulnerability' may not be very accurate

I've drafted this PR to update the policy, and I'm happy with it.  it addresses the feedback we received and doesn't change the substance of the policy at all