### PR TITLE
Update cadence and propose agenda for 2024-03-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,57 +10,26 @@ see [2024-03-13](meetings/2024/2024-03-13.md) and [the backlog](meetings/backlog
 
 ## Meetings
 
-Meetings are bi-weekly, alternating between an APAC-friendly time and an EMEA-friendly time. The meetings appear on the [TC39 private calendar](https://github.com/tc39/Reflector#tc39-private-calendar).
+We meet weekly.
+The meetings appear on the [TC39 private calendar](https://github.com/tc39/Reflector#tc39-private-calendar).
 
-Meeting link: <https://meet.google.com/rwh-opnw-cnk>
-
-<!-- DST below -->
-
-### 2nd Wednesday / Thursday each month (EMEA-friendly)
-
-|              |                 |
-| -----------: | --------------- |
-| US / Central | 12:00 Wednesday |
-|          UTC | 17:00 Wednesday |
-|        China | 01:00 Thursday  |
-
-### 4th Tuesday / Wednesday each month (APAC-friendly)
-
-|              |                 |
-| -----------: | --------------- |
-| US / Central | 20:00 Tuesday   |
-|          UTC | 01:00 Wednesday |
-|        China | 09:00 Wednesday |
-
-<!-- not DST below -->
-
-<!--
-### 2nd Wednesday / Thursday each month (EMEA-friendly)
-
-|              |                 |
-| -----------: | --------------- |
-| US / Central | 12:00 Wednesday |
-|          UTC | 18:00 Wednesday |
-|        China | 02:00 Thursday  |
-
-### 4th Tuesday / Wednesday each month (APAC-friendly)
-
-|              |                 |
-| -----------: | --------------- |
-| US / Central | 20:00 Tuesday   |
-|          UTC | 02:00 Wednesday |
-|        China | 10:00 Wednesday |
--->
+Meeting link: <https://us02web.zoom.us/j/81143085896?pwd=TUE3WGgrdEZmNFZJc0g4QzBHUWczdz09>
 
 ## Folks
 
-- Convenors: [Chris de Almeida](https://github.com/ctcpip), [Jordan Harband](https://github.com/ljharb)
-- Speaker: [Michael Ficarra](https://github.com/michaelficarra)
-- Secretaries: [Samina Husain](https://github.com/SaminaHusain), [Istvan Sebestyen](https://github.com/ecmageneva)
+- Convenors:
+  [Chris de Almeida](https://github.com/ctcpip),
+  [Jordan Harband](https://github.com/ljharb),
+  [Kris Kowal](https://github.com/kriskowal) (pending plenary)
+- Speaker:
+  [Michael Ficarra](https://github.com/michaelficarra)
+- Secretaries:
+  [Samina Husain](https://github.com/SaminaHusain),
+  [Istvan Sebestyen](https://github.com/ecmageneva)
 
 ## Scope
 
-To ensure the ECMAScript® (JavaScript™️) security model is effective for the constantly evolving threat landscape of today and tomorrow.
+To ensure the ECMAScript® (JavaScript™) security model is effective for the constantly evolving threat landscape of today and tomorrow.
 
 ### Programme of work
 

--- a/meetings/2024/2024-03-20.md
+++ b/meetings/2024/2024-03-20.md
@@ -1,0 +1,18 @@
+
+# 18th Meeting of TC39-TG3 - 2024-03-20
+
+## Folks
+
+| Name      | GH Username     | TLA | Affiliation  |
+| --------- | --------------- | --- | ------------ |
+| Full Name | @githubUsername | FNE | organization |
+|           |                 |     |              |
+
+## Agenda
+
+> [!NOTE]
+> See [backlog.md](../backlog.md) for outstanding action items and agenda topics.
+
+| Topic                                                                           | Presenter(s)     |
+| ------------------------------------------------------------------------------- | ---------------- |
+| ShadowRealm interaction with Trusted Types                                      | Caridy Patiño    |


### PR DESCRIPTION
Per 2024-03-13, we’ll meet going forward on a weekly cadence. I’ve changed the meeting link to the old SES meeting link so that I can continue to manage recordings and gently herd stragglers into the new venue. I leave as an exercise to future self to establish a neutral venue (presumably on YouTube) where we can publish meeting recordings.

I’ve also carried over the agenda for the next SES meeting. @caridy has been looking to talk with us about ShadowRealm and TrustedTypes.